### PR TITLE
Update forcefactories.py

### DIFF
--- a/openmmtools/forcefactories.py
+++ b/openmmtools/forcefactories.py
@@ -101,6 +101,8 @@ def restrain_atoms_by_dsl(thermodynamic_state, sampler_state, topology, atoms_ds
     restrained_atoms = mdtraj_topology.select(atoms_dsl).tolist()
     restrain_atoms(thermodynamic_state, sampler_state, restrained_atoms, **kwargs)
 
+    reutrn system
+    
 
 def restrain_atoms(thermodynamic_state, sampler_state, restrained_atoms, sigma=3.0*unit.angstroms):
     """Apply a soft harmonic restraint to the given atoms.
@@ -177,6 +179,8 @@ def restrain_atoms(thermodynamic_state, sampler_state, restrained_atoms, sigma=3
     system.addForce(restraint_force)
     thermodynamic_state.system = system
 
+    return system
+    
 
 if __name__ == '__main__':
     import doctest


### PR DESCRIPTION
When trying to generate a system with restraints on a protein, system generation would crash (see openMM issue https://github.com/openmm/openmm/issues/4841#issue-2911325107). Added 'return system' to both functions under RESTRAINTS to correct this issue.

## Description
Provide a brief description of the PR's purpose here.

## Todos
- [ ] Implement feature / fix bug
- [ ] Add [tests](https://github.com/choderalab/openmmtools/tree/master/openmmtools/tests)
- [ ] Update [documentation](https://github.com/choderalab/openmmtools/tree/master/docs) as needed
- [ ] Update [changelog](https://github.com/choderalab/openmmtools/blob/master/docs/releasehistory.rst) to summarize changes in behavior, enhancements, and bugfixes implemented in this PR

## Status
- [ ] Ready to go

## Changelog message
```

```